### PR TITLE
Upgrade to support nickel 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ typemap = "0.3"
 plugin = "0.2"
 lazy_static = "0.2"
 rand = "0.3"
-nickel = "^0.8"
+nickel = "^0.9"
 
 [dependencies.cookie]
 version = "^0.2"
 default-features = false
 
 [dependencies.hyper]
-version = "^0.8"
+version = "^0.9"
 default-features = false


### PR DESCRIPTION
What do you think of changing this crates' version to match the version of nickel it supports, i.e. make this version 0.9.0 since is supports nickel 0.9.x?
