### PR TITLE
feat(*): bump version to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel_cookies"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kevin Butler <haqkrs@gmail.com>"]
 description = "Cookies support for nickel.rs"
 license = "MIT"


### PR DESCRIPTION
- updates nickel and hyper dependency versions to 0.9